### PR TITLE
feat: 支持配置商品(选项)的原料消耗量，和批量计算订单原料总理 (recv3A5DbVtBAl)

### DIFF
--- a/src/main/java/com/chimera/weapp/entity/Product.java
+++ b/src/main/java/com/chimera/weapp/entity/Product.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import com.chimera.weapp.vo.OptionValue;
+import com.chimera.weapp.vo.InventoryUsage;
 import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
@@ -48,6 +49,8 @@ public class Product {
     private Boolean needStockWithRestrictBuy;
     @Schema(description = "库存数量，为0时前端提示已售罄并不可下单")
     private int stock;
+    @Schema(description = "原料信息和用量列表")
+    private List<InventoryUsage> inventoryList;
     @Schema(description = "预售买数量，补货后清零")
     private int presaleNum;
     @Schema(description = "当天是否已补货，0点设为False")

--- a/src/main/java/com/chimera/weapp/vo/InventoryUsage.java
+++ b/src/main/java/com/chimera/weapp/vo/InventoryUsage.java
@@ -1,0 +1,19 @@
+package com.chimera.weapp.vo;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InventoryUsage {
+    @NotNull
+    private String uuid;
+    @Schema(description = "用量")
+    private double amount;
+}

--- a/src/main/java/com/chimera/weapp/vo/OptionValue.java
+++ b/src/main/java/com/chimera/weapp/vo/OptionValue.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -18,4 +20,6 @@ public class OptionValue {
     private String value;
     @Schema(description = "该可选项的价格调整，>=0。单位也为分。")
     private int priceAdjustment;
+    @Schema(description = "额外原料信息和用量列表")
+    private List<InventoryUsage> inventoryList;
 }


### PR DESCRIPTION
**需求**：recv3A5DbVtBAl 为商品(选项)配置原料消耗量，和批量计算订单原料总需求

**方案**：后端增加 InventoryUsage 接口，把所有商品和商品选项的原料用量存入数据库。前端计算选中订单的原料总量（增加订单一页单量 10 -> 15）

**验证**：手模简单订单情况验证

**风险与回滚**：对旧接口无修改，增加新接口，需要后端同时适配修改。回滚需删除product.inventoryList和optionvalue.inventoryList的表项