### PR TITLE
feat: 支持配置商品(选项)的原料消耗量，和批量计算订单原料总理 (recv3A5DbVtBAl)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,67 @@
+# Backend Environment Variables Example
+# Copy this file to .env and fill in your actual values
+# Note: Spring Boot automatically loads .env files if you have spring-dotenv dependency,
+#       or you can export these variables before running the application.
+#
+# ⚠️  SECURITY WARNING: This file is an EXAMPLE only.
+#    - Change ALL default passwords before production use
+#    - Never commit real credentials to version control
+#    - Use strong, unique passwords for each service
+
+# ============================================
+# Server Configuration
+# ============================================
+SERVER_PORT=8080
+SERVER_PORT_SSL=8443
+
+# ============================================
+# MongoDB Configuration
+# ============================================
+MONGO_HOST=localhost
+MONGO_PORT=27017
+MONGO_DATABASE=chimera
+MONGO_USERNAME=chimera
+MONGO_PASSWORD=change_me_in_production
+MONGO_AUTHENTICATION_DATABASE=admin
+
+# ============================================
+# Application URLs
+# ============================================
+# The public-facing URL of your application
+APP_URL=https://your-domain.com/
+
+# File upload directory (absolute path)
+FILE_UPLOAD_DIR=/opt/chimera/static/
+
+# Static resources location (file: prefix required)
+SPRING_WEB_RESOURCES_STATIC_LOCATIONS=file:/opt/chimera/static/
+
+# ============================================
+# WeChat Mini Program Configuration
+# ============================================
+WECHAT_APPID=wx_your_app_id_here
+WECHAT_SECRET=your_app_secret_here
+WECHAT_MCHID=your_merchant_id
+WECHAT_MERCHANT_SERIAL_NUMBER=your_cert_serial_number
+WECHAT_API_V3_KEY=your_api_v3_key
+WECHAT_PRIVATE_KEY_PATH=/opt/chimera/certs/merchant-private.pem
+WECHATPAY_PUBLIC_KEY_PATH=/opt/chimera/certs/wechatpay-public.pem
+WECHATPAY_PUBLIC_KEY_ID=your_public_key_id
+WECHATPAY_NOTIFICATION_USE_COMBINED=false
+WECHAT_PREPAY_NOTIFY_URL=https://your-domain.com/wechat/prepay_notify
+WECHAT_REFUND_NOTIFY_URL=https://your-domain.com/wechat/refund_notify
+WECHAT_STATE=production
+
+# ============================================
+# Optional Configuration (have sensible defaults)
+# ============================================
+# Timezone for Jackson date serialization
+# TIMEZONE=Asia/Shanghai
+
+# JPA settings (mostly unused with MongoDB)
+# JPA_DDL_AUTO=update
+# JPA_SHOW_SQL=true
+
+# Multipart file upload limits
+# MAX_FILE_SIZE=10MB
+# MAX_REQUEST_SIZE=10MB

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,21 @@ build/
 .vscode/
 src/main/resources/chimeracoffee.top.jks
 src/main/resources/jks-password.txt
+
+### Dev ###
+log/*
+.m2/*
+.local-mongo/*
+.local-static/*
+.tmp/*
+
+### Dev Scripts Runtime ###
+dev-scripts/.local-mongo/
+dev-scripts/.local-static/
+dev-scripts/*.log
+dev-scripts/*.bak
+dev-scripts/*.pid
+dev-scripts/.env.local
+
+### pem files ###
+*.pem

--- a/dev-scripts/README.md
+++ b/dev-scripts/README.md
@@ -1,0 +1,429 @@
+# Chimera Coffee - Development Environment Setup
+
+This directory contains scripts for setting up and managing the local development environment for the Chimera Coffee project.
+
+## Overview
+
+The Chimera Coffee system consists of three components:
+
+1. **Backend** (`../ChimeraCoffee/`) - Java Spring Boot API server
+2. **Management Frontend** (`../chimera-management/`) - Vue 3 admin dashboard
+3. **WeChat Miniapp** (`../chimeracoffeeweb-master/`) - WeChat miniapp for customers
+
+These scripts help you run the **Backend + Management Frontend** for local development.
+
+> ⚠️ **Security Notice**: This setup is intended for **local development only**. Default credentials (admin/admin123, chimera/chimera) and configuration are insecure and should never be used in production. See [Security Considerations](#security-considerations) for details.
+
+---
+
+## Prerequisites
+
+### Required Software
+
+All of these should be installed and available in your PATH:
+
+| Software | Version | Purpose | Download/Install |
+|----------|---------|---------|------------------|
+| **Java** | 17+ | Backend runtime | `apt install openjdk-17-jdk` or [Oracle JDK](https://www.oracle.com/java/technologies/downloads/) |
+| **Maven** | 3.8+ | Build backend | `apt install maven` or [Maven](https://maven.apache.org/download.cgi) |
+| **MongoDB** | 6.0+ | Database | [MongoDB Community](https://www.mongodb.com/try/download/community) |
+| **Node.js** | 18+ | Frontend runtime | [Node.js](https://nodejs.org/) |
+| **npm** | 9+ | Package management | Comes with Node.js |
+
+### MongoDB Requirements
+
+You need both `mongod` (server) and `mongosh` (shell) commands available:
+
+```bash
+# Verify installation
+mongod --version
+mongosh --version
+```
+
+### Verify Prerequisites
+
+Run the info script to check your environment:
+
+```bash
+./dev-info.sh
+```
+
+This will display:
+- Installed software versions
+- Git branch/status for all three repos
+- MongoDB connection status
+- Backend build status
+- Frontend dependencies status
+
+---
+
+## Quick Start
+
+### 1. Clone All Repositories (if not already)
+
+```bash
+# Main directory structure:
+# /your-workspace/
+#   ├── ChimeraCoffee/          # Backend (this repo)
+#   ├── chimera-management/     # Frontend (separate repo)
+#   └── chimeracoffeeweb-master/ # Miniapp (separate repo)
+
+# Clone backend (contains these scripts)
+git clone <backend-repo-url> ChimeraCoffee
+
+# Clone frontend
+git clone <frontend-repo-url> chimera-management
+
+# Clone miniapp (optional for backend/frontend dev)
+git clone <miniapp-repo-url> chimeracoffeeweb-master
+
+# Copy/link scripts to parent directory (optional)
+mkdir -p ../test
+cp -r ChimeraCoffee/dev-scripts/* ../test/
+```
+
+### 2. Start Everything
+
+```bash
+cd test  # or wherever you placed the scripts
+
+# Start backend + frontend
+./dev-start.sh
+```
+
+### 3. Access the Application
+
+Once started, access the services at:
+
+| Service | URL | Credentials |
+|---------|-----|-------------|
+| Management Frontend | http://localhost:5173/shop/ | admin / admin123 |
+| Backend API | http://localhost:8088 | - |
+| API Documentation | http://localhost:8088/swagger-ui.html | - |
+
+### 4. Stop Everything
+
+```bash
+./dev-stop.sh
+```
+
+---
+
+## Scripts Reference
+
+### `dev-info.sh`
+Display development environment information.
+
+```bash
+./dev-info.sh
+```
+
+Shows:
+- Prerequisites status (Java, Maven, MongoDB, Node.js, npm)
+- Git branch and status for all three repos
+- MongoDB running status
+- Backend build status
+- Frontend dependencies status
+
+### `dev-start.sh`
+Start the development environment.
+
+```bash
+# Start backend + frontend (default)
+./dev-start.sh
+
+# Start only backend
+./dev-start.sh --backend-only
+
+# Start only frontend (assumes backend is already running)
+./dev-start.sh --frontend-only
+
+# Skip Maven build (use existing JAR)
+./dev-start.sh --skip-build
+
+# Skip database initialization
+./dev-start.sh --skip-db-init
+
+# Reset MongoDB data (fresh database)
+./dev-start.sh --reset-db
+
+# Combine options
+./dev-start.sh --backend-only --reset-db
+```
+
+**What it does:**
+1. Shows current git branch info for backend/frontend repos
+2. Starts MongoDB (if not running) or connects to existing one
+3. Builds the backend JAR (unless `--skip-build`)
+4. Initializes database with seed data (admin user, sample products)
+5. Starts backend server
+6. Configures frontend to use local backend API
+7. Starts frontend dev server
+
+### `dev-stop.sh`
+Stop the development environment.
+
+```bash
+# Stop backend and MongoDB (default)
+./dev-stop.sh
+
+# Stop only backend, keep MongoDB running
+./dev-stop.sh --soft
+
+# Stop everything and remove MongoDB data
+./dev-stop.sh --clean
+```
+
+### `dev-init-db.sh`
+Initialize database with seed data. Usually called automatically by `dev-start.sh`.
+
+```bash
+# Run standalone (ensure MongoDB is running first)
+./dev-init-db.sh
+```
+
+---
+
+## Configuration
+
+### Environment Variables
+
+You can customize the setup using environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SERVER_PORT` | 8088 | Backend server port |
+| `FRONTEND_PORT` | 5173 | Frontend dev server port |
+| `MONGO_HOST` | 127.0.0.1 | MongoDB host |
+| `MONGO_PORT` | 27017 | MongoDB port |
+| `MONGO_DATABASE` | chimera_local | Database name |
+| `MONGO_USERNAME` | chimera | MongoDB username |
+| `MONGO_PASSWORD` | chimera | MongoDB password |
+| `ADMIN_USERNAME` | admin | Admin login username |
+| `ADMIN_PASSWORD` | admin123 | Admin login password |
+
+> ⚠️ **Security Warning**: The default credentials above are for **local development only**. Never use these defaults in production. Always change passwords before deploying.
+
+Example:
+```bash
+SERVER_PORT=9090 FRONTEND_PORT=3000 ./dev-start.sh
+```
+
+### Using External MongoDB
+
+If you have your own MongoDB instance running:
+
+```bash
+export MONGO_HOST=your.mongodb.host
+export MONGO_PORT=27017
+export MONGO_DATABASE=your_db
+export MONGO_USERNAME=your_user
+export MONGO_PASSWORD=your_pass
+
+./dev-start.sh
+```
+
+The script will detect that MongoDB is already running and skip starting a local instance.
+
+---
+
+## Project Structure
+
+```
+/workspace/
+├── ChimeraCoffee/              # Backend (Spring Boot)
+│   ├── src/
+│   ├── target/                 # Build output
+│   ├── .local-mongo/          # Local MongoDB data (auto-created)
+│   ├── .local-static/         # Uploaded files storage
+│   ├── .m2/                   # Local Maven repository
+│   └── log/                   # Log files
+│
+├── chimera-management/         # Frontend (Vue 3)
+│   ├── src/
+│   ├── dist/                  # Build output
+│   ├── node_modules/          # Dependencies
+│   └── .env.local             # Auto-generated dev config
+│
+├── chimeracoffeeweb-master/    # WeChat Miniapp (optional)
+│   └── miniprogram/
+│
+└── test/                       # These scripts
+    ├── dev-info.sh
+    ├── dev-start.sh
+    ├── dev-stop.sh
+    ├── dev-init-db.sh
+    └── README.md
+```
+
+---
+
+## Seed Data
+
+The database is initialized with minimal test data:
+
+### Admin User
+- **Username**: `admin`
+- **Password**: `admin123`
+- **Role**: `ADMIN`
+
+### Inventory
+| Name | Type | Unit | Initial Stock |
+|------|------|------|---------------|
+| Coffee Beans | raw | g | 10,000 |
+| Milk | raw | ml | 5,000 |
+| Sugar | raw | g | 2,000 |
+
+### Products
+| Name | Price | Student Price | Description |
+|------|-------|---------------|-------------|
+| Latte | ¥24.00 | ¥22.00 | Classic espresso with steamed milk |
+| Americano | ¥18.00 | ¥16.00 | Espresso with hot water |
+
+### Product Options
+- **Size**: Small, Large (+¥2.00)
+- **Temperature**: Hot, Iced
+
+---
+
+## Troubleshooting
+
+### Port Already in Use
+
+```bash
+# Check what's using port 8088
+lsof -i :8088
+
+# Use different ports
+SERVER_PORT=9090 FRONTEND_PORT=3000 ./dev-start.sh
+```
+
+### MongoDB Connection Failed
+
+```bash
+# Check if MongoDB is running
+mongosh --eval "db.runCommand({ ping: 1 })"
+
+# Reset MongoDB data
+./dev-start.sh --reset-db
+```
+
+### Frontend Shows Connection Error
+
+Make sure backend is running:
+```bash
+curl http://localhost:8088/swagger-ui.html
+```
+
+Or restart both:
+```bash
+./dev-stop.sh
+./dev-start.sh
+```
+
+### Build Fails
+
+Try clean build:
+```bash
+cd ../ChimeraCoffee
+mvn clean
+./test/dev-start.sh
+```
+
+---
+
+## Git Branch Information
+
+The scripts will display the current branch for each repository but **will NOT auto-checkout** any branches. You are responsible for being on the correct branch for your work.
+
+To see current branches:
+```bash
+./dev-info.sh
+```
+
+---
+
+## Miniapp Development
+
+The WeChat miniapp (`chimeracoffeeweb-master/`) is **NOT** started by these scripts. To develop the miniapp:
+
+1. Install [WeChat DevTools](https://developers.weixin.qq.com/miniprogram/dev/devtools/download.html)
+2. Open the `chimeracoffeeweb-master` directory in DevTools
+3. Configure the miniapp to point to your local backend (requires ngrok or similar for WeChat callbacks)
+
+---
+
+## Logs
+
+- Backend logs: `../ChimeraCoffee/log/backend_*.log`
+- MongoDB logs: `../ChimeraCoffee/log/mongo.log`
+- Frontend logs: Console output (Vite dev server)
+
+---
+
+## Contributing
+
+When adding new features that require configuration:
+
+1. **Backend**: Use environment variables in `application.properties`:
+   ```properties
+   my.new.config=${MY_NEW_CONFIG:default_value}
+   ```
+
+2. **Frontend**: Add to `.env` files and use `import.meta.env`:
+   ```typescript
+   const config = import.meta.env.VITE_MY_NEW_CONFIG || 'default';
+   ```
+
+3. **Scripts**: Update the dev scripts to set appropriate defaults
+
+---
+
+## Security Considerations
+
+### Default Credentials (Development Only)
+
+The development environment uses default credentials that are **insecure by design**:
+
+| Service | Username | Password | Note |
+|---------|----------|----------|------|
+| Admin User | `admin` | `admin123` | Change immediately if exposed to network |
+| MongoDB | `chimera` | `chimera` | Local development only |
+
+**⚠️ Never use these credentials in production or on publicly accessible systems.**
+
+### Local Development Safety
+
+These scripts are designed for **local development only**:
+- MongoDB binds to `127.0.0.1` (localhost) by default
+- No encryption between services (HTTP only)
+- Debug logging enabled
+- CORS configured to allow all origins
+
+### Before Production Deployment
+
+1. Change all default passwords
+2. Use strong, unique passwords for each service
+3. Enable MongoDB authentication
+4. Use HTTPS with valid SSL certificates
+5. Configure firewall rules
+6. Disable unnecessary debug logging
+7. Review and harden all configuration
+
+See [DEPLOYMENT_GUIDE.md](../DEPLOYMENT_GUIDE.md) for production deployment instructions.
+
+---
+
+## Support
+
+For issues or questions:
+- Check the troubleshooting section above
+- Review the logs in `../ChimeraCoffee/log/`
+- Consult the project documentation
+- Ask in the team chat
+
+---
+
+## License
+
+[Your License Here]

--- a/dev-scripts/dev-info.sh
+++ b/dev-scripts/dev-info.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# dev-info.sh - Display development environment information
+# Shows git branch/status for all three repos and checks prerequisites
+
+# Auto-detect directory structure
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)"
+
+if [[ -f "${SCRIPT_DIR}/../pom.xml" ]]; then
+    # We're in ChimeraCoffee/dev-scripts/ (new structure)
+    BACKEND_DIR="${SCRIPT_DIR}/.."
+    BASE_DIR="${BACKEND_DIR}/.."
+else
+    # We're in project_root/test/ (legacy structure)
+    BASE_DIR="${SCRIPT_DIR}/.."
+    BACKEND_DIR="${BASE_DIR}/ChimeraCoffee"
+fi
+
+FRONTEND_DIR="${BASE_DIR}/chimera-management"
+MINIAPP_DIR="${BASE_DIR}/chimeracoffeeweb-master"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+log_info() { echo -e "${BLUE}[INFO]${NC} $*"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*"; }
+log_success() { echo -e "${GREEN}[OK]${NC} $*"; }
+
+print_separator() {
+    echo "=================================================="
+}
+
+check_prerequisites() {
+    print_separator
+    log_info "Checking Prerequisites"
+    print_separator
+    
+    local all_ok=true
+    
+    # Java
+    if command -v java >/dev/null 2>&1; then
+        local java_version
+        java_version=$(java -version 2>&1 | head -n1 | cut -d'"' -f2)
+        log_success "Java: $java_version"
+    else
+        log_error "Java: NOT FOUND (required: Java 17+)"
+        all_ok=false
+    fi
+    
+    # Maven
+    if command -v mvn >/dev/null 2>&1; then
+        local mvn_version
+        mvn_version=$(mvn --version 2>/dev/null | head -n1 | cut -d' ' -f3)
+        log_success "Maven: $mvn_version"
+    else
+        log_error "Maven: NOT FOUND"
+        all_ok=false
+    fi
+    
+    # MongoDB
+    if command -v mongod >/dev/null 2>&1 && command -v mongosh >/dev/null 2>&1; then
+        local mongo_version
+        mongo_version=$(mongod --version 2>/dev/null | head -n1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)
+        log_success "MongoDB: $mongo_version"
+    else
+        log_error "MongoDB: NOT FOUND (mongod and mongosh required)"
+        all_ok=false
+    fi
+    
+    # Node.js
+    if command -v node >/dev/null 2>&1; then
+        local node_version
+        node_version=$(node -v)
+        log_success "Node.js: $node_version"
+    else
+        log_error "Node.js: NOT FOUND"
+        all_ok=false
+    fi
+    
+    # npm
+    if command -v npm >/dev/null 2>&1; then
+        local npm_version
+        npm_version=$(npm -v)
+        log_success "npm: $npm_version"
+    else
+        log_error "npm: NOT FOUND"
+        all_ok=false
+    fi
+    
+    if $all_ok; then
+        echo ""
+        log_success "All prerequisites satisfied!"
+    else
+        echo ""
+        log_error "Some prerequisites are missing. Please install them first."
+        exit 1
+    fi
+}
+
+git_repo_info() {
+    local repo_dir="$1"
+    local repo_name="$2"
+    
+    print_separator
+    log_info "Repository: $repo_name"
+    print_separator
+    
+    if [[ ! -d "$repo_dir/.git" ]]; then
+        log_error "Not a git repository: $repo_dir"
+        return 1
+    fi
+    
+    local branch
+    branch=$(git -C "$repo_dir" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+    
+    local commit
+    commit=$(git -C "$repo_dir" rev-parse --short HEAD 2>/dev/null || echo "unknown")
+    
+    local status
+    if git -C "$repo_dir" status --porcelain 2>/dev/null | grep -q .; then
+        status="${YELLOW}dirty (uncommitted changes)${NC}"
+    else
+        status="${GREEN}clean${NC}"
+    fi
+    
+    echo "  Directory: $repo_dir"
+    echo -e "  Branch:    ${GREEN}$branch${NC}"
+    echo "  Commit:    $commit"
+    echo -e "  Status:    $status"
+    
+    # Show last commit info
+    local last_commit
+    last_commit=$(git -C "$repo_dir" log -1 --format="%h - %s (%ar)" 2>/dev/null || echo "N/A")
+    echo "  Last:      $last_commit"
+}
+
+check_mongo_status() {
+    print_separator
+    log_info "MongoDB Status"
+    print_separator
+    
+    local mongo_host="${MONGO_HOST:-127.0.0.1}"
+    local mongo_port="${MONGO_PORT:-27017}"
+    
+    if mongosh "mongodb://${mongo_host}:${mongo_port}/admin" --quiet --eval "db.runCommand({ ping: 1 })" >/dev/null 2>&1; then
+        log_success "MongoDB is running on ${mongo_host}:${mongo_port}"
+        local mongo_version
+        mongo_version=$(mongosh "mongodb://${mongo_host}:${mongo_port}/admin" --quiet --eval "db.version()" 2>/dev/null || echo "unknown")
+        echo "  Version: $mongo_version"
+    else
+        log_warn "MongoDB is NOT running on ${mongo_host}:${mongo_port}"
+        echo "  Run './dev-start.sh' to start it automatically, or start your own MongoDB instance"
+    fi
+}
+
+check_backend_build() {
+    print_separator
+    log_info "Backend Build Status"
+    print_separator
+    
+    local jar_files
+    jar_files=$(ls -1 "${BACKEND_DIR}/target/"*.jar 2>/dev/null | grep -v '\.original$' || true)
+    
+    if [[ -n "$jar_files" ]]; then
+        log_success "Backend JAR found:"
+        echo "$jar_files" | while read -r jar; do
+            local jar_size
+            jar_size=$(du -h "$jar" 2>/dev/null | cut -f1)
+            echo "  - $(basename "$jar") ($jar_size)"
+        done
+    else
+        log_warn "Backend JAR not found. Need to build."
+        echo "  Run './dev-start.sh' to build automatically"
+    fi
+}
+
+check_frontend_deps() {
+    print_separator
+    log_info "Frontend Dependencies Status"
+    print_separator
+    
+    if [[ -d "${FRONTEND_DIR}/node_modules" ]]; then
+        local pkg_count
+        pkg_count=$(ls -1 "${FRONTEND_DIR}/node_modules" 2>/dev/null | wc -l)
+        log_success "Frontend dependencies installed ($pkg_count packages)"
+    else
+        log_warn "Frontend node_modules not found. Need to run 'npm install'."
+    fi
+}
+
+main() {
+    echo ""
+    echo "╔══════════════════════════════════════════════════╗"
+    echo "║    Chimera Coffee - Dev Environment Info         ║"
+    echo "╚══════════════════════════════════════════════════╝"
+    echo ""
+    
+    check_prerequisites
+    echo ""
+    
+    git_repo_info "$BACKEND_DIR" "Backend (ChimeraCoffee)"
+    echo ""
+    
+    git_repo_info "$FRONTEND_DIR" "Frontend (chimera-management)"
+    echo ""
+    
+    git_repo_info "$MINIAPP_DIR" "Miniapp (chimeracoffeeweb-master)"
+    echo ""
+    
+    check_mongo_status
+    echo ""
+    
+    check_backend_build
+    echo ""
+    
+    check_frontend_deps
+    echo ""
+    
+    print_separator
+    log_info "Quick Start Commands"
+    print_separator
+    echo ""
+    echo "  Start everything:     ./dev-start.sh"
+    echo "  Stop everything:      ./dev-stop.sh"
+    echo "  View this info:       ./dev-info.sh"
+    echo ""
+    echo "  Backend only:         ./dev-start.sh --backend-only"
+    echo "  Frontend only:        ./dev-start.sh --frontend-only"
+    echo ""
+    echo "  Access URLs (when running):"
+    echo "    Backend API:    http://localhost:8088"
+    echo "    Frontend:       http://localhost:5173"
+    echo "    API Docs:       http://localhost:8088/swagger-ui.html"
+    echo ""
+}
+
+main "$@"

--- a/dev-scripts/dev-init-db.sh
+++ b/dev-scripts/dev-init-db.sh
@@ -1,0 +1,423 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# dev-init-db.sh - Initialize MongoDB with seed data for development
+# This script is typically called by dev-start.sh, but can be run standalone
+#
+# Environment variables (all have defaults):
+#   MONGO_HOST, MONGO_PORT, MONGO_DATABASE
+#   MONGO_USERNAME, MONGO_PASSWORD, MONGO_AUTHENTICATION_DATABASE
+#   ADMIN_USERNAME, ADMIN_PASSWORD
+#   MAVEN_LOCAL_REPO (for jbcrypt jar)
+
+# Auto-detect directory structure
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)"
+
+if [[ -f "${SCRIPT_DIR}/../pom.xml" ]]; then
+    # We're in ChimeraCoffee/dev-scripts/ (new structure)
+    BACKEND_DIR="${SCRIPT_DIR}/.."
+else
+    # We're in project_root/test/ (legacy structure)
+    BACKEND_DIR="${SCRIPT_DIR}/../ChimeraCoffee"
+fi
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info() { echo -e "${BLUE}[DB]${NC} $*"; }
+log_warn() { echo -e "${YELLOW}[DB]${NC} $*"; }
+log_error() { echo -e "${RED}[DB]${NC} $*"; }
+log_success() { echo -e "${GREEN}[DB]${NC} $*"; }
+
+# Configuration with defaults
+: "${MONGO_HOST:=127.0.0.1}"
+: "${MONGO_PORT:=27017}"
+: "${MONGO_DATABASE:=chimera_local}"
+: "${MONGO_USERNAME:=chimera}"
+: "${MONGO_PASSWORD:=chimera}"
+: "${MONGO_AUTHENTICATION_DATABASE:=admin}"
+: "${ADMIN_USERNAME:=admin}"
+: "${ADMIN_PASSWORD:=admin123}"
+
+MONGO_URI="mongodb://${MONGO_USERNAME}:${MONGO_PASSWORD}@${MONGO_HOST}:${MONGO_PORT}/${MONGO_DATABASE}?authSource=${MONGO_AUTHENTICATION_DATABASE}"
+
+# Verify MongoDB is accessible
+log_info "Connecting to MongoDB at ${MONGO_HOST}:${MONGO_PORT}..."
+
+if ! mongosh "$MONGO_URI" --quiet --eval "db.runCommand({ ping: 1 })" >/dev/null 2>&1; then
+    log_error "Cannot connect to MongoDB"
+    log_error "URI: ${MONGO_URI//${MONGO_PASSWORD}/***}"
+    exit 1
+fi
+
+log_success "Connected to MongoDB"
+
+# Generate admin password hash using bcrypt
+log_info "Generating admin password hash..."
+
+# Find jbcrypt jar
+if [[ -z "${JBCRYPT_JAR:-}" ]]; then
+    if [[ -n "${MAVEN_LOCAL_REPO:-}" ]]; then
+        JBCRYPT_JAR="${MAVEN_LOCAL_REPO}/org/mindrot/jbcrypt/0.4/jbcrypt-0.4.jar"
+    elif [[ -n "${MAVEN_USER_HOME:-}" ]]; then
+        JBCRYPT_JAR="${MAVEN_USER_HOME}/repository/org/mindrot/jbcrypt/0.4/jbcrypt-0.4.jar"
+    else
+        JBCRYPT_JAR="${BACKEND_DIR}/.m2/repository/org/mindrot/jbcrypt/0.4/jbcrypt-0.4.jar"
+    fi
+fi
+
+if [[ ! -f "$JBCRYPT_JAR" ]]; then
+    log_warn "jbcrypt jar not found at $JBCRYPT_JAR"
+    log_info "Attempting to download with Maven..."
+    
+    mkdir -p "${BACKEND_DIR}/.m2"
+    mvn dependency:get \
+        -Dartifact=org.mindrot:jbcrypt:0.4 \
+        -Dmaven.repo.local="${BACKEND_DIR}/.m2/repository" \
+        -q
+    
+    JBCRYPT_JAR="${BACKEND_DIR}/.m2/repository/org/mindrot/jbcrypt/0.4/jbcrypt-0.4.jar"
+fi
+
+if [[ ! -f "$JBCRYPT_JAR" ]]; then
+    log_error "Could not obtain jbcrypt jar"
+    exit 1
+fi
+
+# Create temporary directory for compilation
+TMP_DIR="${BACKEND_DIR}/.tmp/bcrypt-$$"
+mkdir -p "$TMP_DIR"
+
+# Compile and run password hasher
+cat > "${TMP_DIR}/HashPw.java" <<'JAVA'
+import org.mindrot.jbcrypt.BCrypt;
+public class HashPw {
+    public static void main(String[] args) {
+        if (args.length < 1) {
+            System.err.println("Usage: HashPw <password>");
+            System.exit(1);
+        }
+        System.out.print(BCrypt.hashpw(args[0], BCrypt.gensalt()));
+    }
+}
+JAVA
+
+javac -cp "$JBCRYPT_JAR" "${TMP_DIR}/HashPw.java" 2>/dev/null
+ADMIN_PASSWORD_HASH=$(java -cp "$JBCRYPT_JAR:$TMP_DIR" HashPw "$ADMIN_PASSWORD")
+rm -rf "$TMP_DIR"
+
+log_success "Password hash generated"
+
+# Seed database
+log_info "Seeding database..."
+
+export MONGO_DATABASE ADMIN_USERNAME ADMIN_PASSWORD_HASH
+
+mongosh "$MONGO_URI" --quiet <<'MONGOSCRIPT'
+const dbName = process.env.MONGO_DATABASE;
+const adminUser = process.env.ADMIN_USERNAME;
+const adminHash = process.env.ADMIN_PASSWORD_HASH;
+
+const db = db.getSiblingDB(dbName);
+
+// 1. Admin user
+const userResult = db.user.updateOne(
+    { name: adminUser, role: "ADMIN" },
+    {
+        $set: { hashedPassword: adminHash },
+        $setOnInsert: {
+            name: adminUser,
+            role: "ADMIN",
+            createdAt: new Date(),
+            studentCert: false,
+            expend: 0,
+            orderNum: 0,
+            points: 0
+        }
+    },
+    { upsert: true }
+);
+
+if (userResult.upsertedCount > 0) {
+    print('Created admin user: ' + adminUser);
+} else {
+    print('Updated admin user password: ' + adminUser);
+}
+
+// Helper function
+function ensureInventory(name, unit, type, remain) {
+    let doc = db.inventory.findOne({ name, deleted: false });
+    if (!doc) {
+        doc = {
+            _id: new ObjectId(),
+            name,
+            unit,
+            type,
+            remain,
+            deleted: false
+        };
+        db.inventory.insertOne(doc);
+        print('Created inventory: ' + name);
+    }
+    return doc;
+}
+
+// 2. Inventory items
+const coffeeBean = ensureInventory("Coffee Beans", "g", "raw", 10000);
+const milk = ensureInventory("Milk", "ml", "raw", 5000);
+const sugar = ensureInventory("Sugar", "g", "raw", 2000);
+
+// 3. Product category
+let cate = db.product_cate.findOne({ title: "Coffee", delete: 0 });
+if (!cate) {
+    cate = {
+        _id: new ObjectId(),
+        title: "Coffee",
+        status: 1,
+        priority: 1,
+        delete: 0
+    };
+    db.product_cate.insertOne(cate);
+    print('Created category: Coffee');
+}
+
+// 4. Product options
+const sizeOptionValues = [
+    { uuid: "size_small", value: "Small", priceAdjustment: 0, inventoryList: [] },
+    { uuid: "size_large", value: "Large", priceAdjustment: 200, inventoryList: [{ uuid: milk._id.valueOf(), amount: 50 }] }
+];
+
+let sizeOption = db.product_option.findOne({ name: "Size" });
+if (!sizeOption) {
+    sizeOption = { _id: new ObjectId(), name: "Size", values: sizeOptionValues };
+    db.product_option.insertOne(sizeOption);
+    print('Created option: Size');
+}
+
+const tempOptionValues = [
+    { uuid: "temp_hot", value: "Hot", priceAdjustment: 0, inventoryList: [] },
+    { uuid: "temp_iced", value: "Iced", priceAdjustment: 0, inventoryList: [] }
+];
+
+let tempOption = db.product_option.findOne({ name: "Temperature" });
+if (!tempOption) {
+    tempOption = { _id: new ObjectId(), name: "Temperature", values: tempOptionValues };
+    db.product_option.insertOne(tempOption);
+    print('Created option: Temperature');
+}
+
+// 5. Sample products
+const baseInventory = [
+    { uuid: coffeeBean._id.valueOf(), amount: 18 },
+    { uuid: milk._id.valueOf(), amount: 200 }
+];
+
+const latteOptions = {};
+latteOptions[sizeOption._id.valueOf()] = sizeOptionValues;
+latteOptions[tempOption._id.valueOf()] = tempOptionValues;
+
+let latte = db.product.findOne({ name: "Latte", delete: 0 });
+if (!latte) {
+    db.product.insertOne({
+        _id: new ObjectId(),
+        cateId: cate._id,
+        name: "Latte",
+        imgURL: "",
+        imgURL_small: "",
+        price: 2400,
+        stuPrice: 2200,
+        describe: "Classic espresso with steamed milk",
+        short_desc: "Espresso + Steamed Milk",
+        status: 1,
+        delete: 0,
+        productOptions: latteOptions,
+        needStockWithRestrictBuy: false,
+        stock: 999,
+        inventoryList: baseInventory,
+        presaleNum: 0,
+        stocked: true,
+        onlyDining: false,
+        onlyDelivery: false,
+        no_coupon: false,
+        rank: 1
+    });
+    print('Created product: Latte');
+}
+
+let americano = db.product.findOne({ name: "Americano", delete: 0 });
+if (!americano) {
+    db.product.insertOne({
+        _id: new ObjectId(),
+        cateId: cate._id,
+        name: "Americano",
+        imgURL: "",
+        imgURL_small: "",
+        price: 1800,
+        stuPrice: 1600,
+        describe: "Espresso with hot water",
+        short_desc: "Espresso + Water",
+        status: 1,
+        delete: 0,
+        productOptions: {},
+        needStockWithRestrictBuy: false,
+        stock: 999,
+        inventoryList: [{ uuid: coffeeBean._id.valueOf(), amount: 18 }],
+        presaleNum: 0,
+        stocked: true,
+        onlyDining: false,
+        onlyDelivery: false,
+        no_coupon: false,
+        rank: 2
+    });
+    print('Created product: Americano');
+}
+
+// 6. State Machine Processor Map
+// Clear existing mappings
+db.processor_map.deleteMany({});
+
+// Processor 0: NotifyPrePay - handles payment notification from PRE_PAID to PAID
+// This applies to all customer types and all scenes
+db.processor_map.insertOne({
+    state: "预支付",
+    event: "支付成功",
+    customerTypes: ["北大学生业务", "清华学生业务", "未学生认证业务"],
+    scenes: ["堂食", "外带", "定时达", "校庆场景"],
+    processorIds: [0]
+});
+
+// Processor 1: NeedDineInFromAllTypesOfCustomer - from PAID to WAITING_DINE_IN
+// Applies to all customer types for DINE_IN scene
+db.processor_map.insertOne({
+    state: "已支付",
+    event: "需要堂食",
+    customerTypes: ["北大学生业务", "清华学生业务", "未学生认证业务"],
+    scenes: ["堂食"],
+    processorIds: [1]
+});
+
+// Processor 8: NeedTakeOutFromAllTypesOfCustomer - from PAID to WAITING_TAKE_OUT
+// Applies to all customer types for TAKE_OUT scene
+db.processor_map.insertOne({
+    state: "已支付",
+    event: "需要外带",
+    customerTypes: ["北大学生业务", "清华学生业务", "未学生认证业务"],
+    scenes: ["外带"],
+    processorIds: [8]
+});
+
+// Processor 2: NeedFixDeliveryFromCertifiedStudent - from PAID to WAITING_FIX_DELIVERY
+// Applies to certified students for FIX_DELIVERY scene
+db.processor_map.insertOne({
+    state: "已支付",
+    event: "需要定时达",
+    customerTypes: ["北大学生业务", "清华学生业务"],
+    scenes: ["定时达"],
+    processorIds: [2]
+});
+
+// Processor 3: SupplyDineIn - from WAITING_DINE_IN to NORMAL_END
+db.processor_map.insertOne({
+    state: "待出餐",
+    event: "提供堂食",
+    customerTypes: ["北大学生业务", "清华学生业务", "未学生认证业务"],
+    scenes: ["堂食"],
+    processorIds: [3]
+});
+
+// Processor 9: SupplyTakeOut - from WAITING_TAKE_OUT to NORMAL_END
+db.processor_map.insertOne({
+    state: "待出餐",
+    event: "提供外带",
+    customerTypes: ["北大学生业务", "清华学生业务", "未学生认证业务"],
+    scenes: ["外带"],
+    processorIds: [9]
+});
+
+// Processor 4: SupplyFixDelivery - from WAITING_FIX_DELIVERY to NORMAL_END
+db.processor_map.insertOne({
+    state: "待配送",
+    event: "提供定时达",
+    customerTypes: ["北大学生业务", "清华学生业务"],
+    scenes: ["定时达"],
+    processorIds: [4]
+});
+
+// Processor 10: RefundApply - can be applied to multiple states
+db.processor_map.insertOne({
+    state: "已支付",
+    event: "退款申请",
+    customerTypes: ["北大学生业务", "清华学生业务", "未学生认证业务"],
+    scenes: ["堂食", "外带", "定时达", "校庆场景"],
+    processorIds: [10]
+});
+
+db.processor_map.insertOne({
+    state: "待出餐",
+    event: "退款申请",
+    customerTypes: ["北大学生业务", "清华学生业务", "未学生认证业务"],
+    scenes: ["堂食", "外带", "定时达", "校庆场景"],
+    processorIds: [10]
+});
+
+db.processor_map.insertOne({
+    state: "待配送",
+    event: "退款申请",
+    customerTypes: ["北大学生业务", "清华学生业务"],
+    scenes: ["定时达"],
+    processorIds: [10]
+});
+
+// Processor 11: RefundCallBack - handles refund notification
+db.processor_map.insertOne({
+    state: "等待退款通知",
+    event: "退款结果通知",
+    customerTypes: ["北大学生业务", "清华学生业务", "未学生认证业务"],
+    scenes: ["堂食", "外带", "定时达", "校庆场景"],
+    processorIds: [11]
+});
+
+print('Created processor_map entries');
+
+// 7. App Configuration (required for order processing)
+const appConfigs = [
+    { key: "dineInController", value: "开", desc: "堂食开关：开/关" },
+    { key: "deliveryController", value: "开", desc: "定时达开关：开/关" },
+    { key: "points_conversion_ratio", value: "10", desc: "积分兑换比例（分）" },
+    { key: "the_period_of_time", value: "300000", desc: "自动发送供餐事件的延迟时间（毫秒）" },
+    { key: "periodically_send_event_switch", value: "F", desc: "定时发送事件开关：T/F" },
+    { key: "periodically_send_event_start_time", value: "08:00", desc: "定时发送事件开始时间" },
+    { key: "periodically_send_event_end_time", value: "22:00", desc: "定时发送事件结束时间" },
+    { key: "contact_phone_number", value: "13800138000", desc: "联系电话" },
+    { key: "shop_address", value: "清华大学", desc: "店铺地址" }
+];
+
+appConfigs.forEach(cfg => {
+    const result = db.app_configuration.updateOne(
+        { key: cfg.key },
+        { 
+            $set: { value: cfg.value },
+            $setOnInsert: { 
+                key: cfg.key,
+                createdAt: new Date(),
+                updatedAt: new Date()
+            }
+        },
+        { upsert: true }
+    );
+    if (result.upsertedCount > 0) {
+        print('Created app_config: ' + cfg.key + ' = ' + cfg.value);
+    } else {
+        print('Updated app_config: ' + cfg.key + ' = ' + cfg.value);
+    }
+});
+
+print('Database seeding complete!');
+MONGOSCRIPT
+
+log_success "Database initialization complete"
+log_info "Admin user: ${ADMIN_USERNAME} / ${ADMIN_PASSWORD}"

--- a/dev-scripts/dev-start.sh
+++ b/dev-scripts/dev-start.sh
@@ -1,0 +1,574 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# dev-start.sh - Start the Chimera Coffee development environment
+# 
+# This script:
+#   - Checks prerequisites
+#   - Shows current git branch info (no auto-checkout)
+#   - Starts/verifies MongoDB
+#   - Builds backend if needed
+#   - Initializes database with seed data
+#   - Starts backend server
+#   - Starts frontend dev server (optional)
+#
+# Usage:
+#   ./dev-start.sh              # Start backend + frontend
+#   ./dev-start.sh --backend-only   # Start only backend
+#   ./dev-start.sh --frontend-only  # Start only frontend
+#   ./dev-start.sh --skip-build     # Skip Maven build (use existing JAR)
+#   ./dev-start.sh --skip-db-init   # Skip database initialization
+#   ./dev-start.sh --reset-db       # Reset MongoDB data directory
+
+# Auto-detect directory structure
+# Supports both:
+#   1. Scripts in project_root/test/ (legacy)
+#   2. Scripts in project_root/ChimeraCoffee/dev-scripts/ (new)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)"
+
+if [[ -f "${SCRIPT_DIR}/../pom.xml" ]]; then
+    # We're in ChimeraCoffee/dev-scripts/ (new structure)
+    BACKEND_DIR="${SCRIPT_DIR}/.."
+    BASE_DIR="${BACKEND_DIR}/.."
+    FRONTEND_DIR="${BASE_DIR}/chimera-management"
+else
+    # We're in project_root/test/ (legacy structure)
+    BASE_DIR="${SCRIPT_DIR}/.."
+    BACKEND_DIR="${BASE_DIR}/ChimeraCoffee"
+    FRONTEND_DIR="${BASE_DIR}/chimera-management"
+fi
+
+LOG_DIR="${BACKEND_DIR}/log"
+mkdir -p "$LOG_DIR"
+
+# PID files
+BACKEND_PID_FILE="${LOG_DIR}/backend.pid"
+MONGO_PID_FILE="${LOG_DIR}/mongo.pid"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info() { echo -e "${BLUE}[INFO]${NC} $*"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*"; }
+log_success() { echo -e "${GREEN}[OK]${NC} $*"; }
+
+# Default config
+: "${SERVER_PORT:=8088}"
+: "${FRONTEND_PORT:=5173}"
+
+: "${MONGO_HOST:=127.0.0.1}"
+: "${MONGO_PORT:=27017}"
+: "${MONGO_DATABASE:=chimera_local}"
+: "${MONGO_USERNAME:=chimera}"
+: "${MONGO_PASSWORD:=chimera}"
+: "${MONGO_AUTHENTICATION_DATABASE:=admin}"
+
+: "${ADMIN_USERNAME:=admin}"
+: "${ADMIN_PASSWORD:=admin123}"
+
+# Java configuration - prefer Java 17 for compatibility
+setup_java() {
+    if [[ -z "${JAVA_HOME:-}" ]]; then
+        # Try to find Java 17
+        if [[ -x "/usr/lib/jvm/java-17-openjdk-amd64/bin/java" ]]; then
+            export JAVA_HOME="/usr/lib/jvm/java-17-openjdk-amd64"
+            export PATH="$JAVA_HOME/bin:$PATH"
+            log_info "Using Java 17 from $JAVA_HOME"
+        elif [[ -x "/usr/lib/jvm/java-17/bin/java" ]]; then
+            export JAVA_HOME="/usr/lib/jvm/java-17"
+            export PATH="$JAVA_HOME/bin:$PATH"
+            log_info "Using Java 17 from $JAVA_HOME"
+        fi
+    fi
+    
+    local java_version
+    java_version=$(java -version 2>&1 | head -n1 | cut -d'"' -f2 | cut -d'.' -f1)
+    if [[ "$java_version" != "17" ]]; then
+        log_warn "Java version is $java_version, but Java 17 is recommended for this project"
+    fi
+}
+
+# Flags
+BACKEND_ONLY=0
+FRONTEND_ONLY=0
+SKIP_BUILD=0
+SKIP_DB_INIT=0
+RESET_DB=0
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --backend-only)
+                BACKEND_ONLY=1
+                shift
+                ;;
+            --frontend-only)
+                FRONTEND_ONLY=1
+                shift
+                ;;
+            --skip-build)
+                SKIP_BUILD=1
+                shift
+                ;;
+            --skip-db-init)
+                SKIP_DB_INIT=1
+                shift
+                ;;
+            --reset-db)
+                RESET_DB=1
+                shift
+                ;;
+            --help|-h)
+                echo "Usage: $0 [options]"
+                echo ""
+                echo "Options:"
+                echo "  --backend-only    Start only the backend"
+                echo "  --frontend-only   Start only the frontend"
+                echo "  --skip-build      Skip Maven build (use existing JAR)"
+                echo "  --skip-db-init    Skip database initialization"
+                echo "  --reset-db        Reset MongoDB data directory before starting"
+                echo "  --help, -h        Show this help"
+                echo ""
+                echo "Environment variables:"
+                echo "  SERVER_PORT       Backend port (default: 8088)"
+                echo "  FRONTEND_PORT     Frontend port (default: 5173)"
+                echo "  MONGO_*           MongoDB configuration"
+                exit 0
+                ;;
+            *)
+                log_error "Unknown option: $1"
+                exit 1
+                ;;
+        esac
+    done
+}
+
+need_cmd() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        log_error "Missing required command: $1"
+        exit 1
+    fi
+}
+
+print_banner() {
+    echo ""
+    echo "╔══════════════════════════════════════════════════╗"
+    echo "║    Chimera Coffee - Dev Environment Startup      ║"
+    echo "╚══════════════════════════════════════════════════╝"
+    echo ""
+}
+
+show_repo_info() {
+    log_info "Repository Status:"
+    echo ""
+    
+    for repo_dir in "$BACKEND_DIR" "$FRONTEND_DIR"; do
+        local repo_name
+        repo_name=$(basename "$repo_dir")
+        local branch
+        branch=$(git -C "$repo_dir" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+        local commit
+        commit=$(git -C "$repo_dir" rev-parse --short HEAD 2>/dev/null || echo "unknown")
+        local dirty=""
+        if git -C "$repo_dir" status --porcelain 2>/dev/null | grep -q .; then
+            dirty=" ${YELLOW}(dirty)${NC}"
+        fi
+        echo "  $repo_name: ${GREEN}$branch${NC} @ $commit$dirty"
+    done
+    echo ""
+}
+
+# MongoDB functions
+ping_mongo() {
+    local uri="mongodb://${MONGO_USERNAME}:${MONGO_PASSWORD}@${MONGO_HOST}:${MONGO_PORT}/${MONGO_DATABASE}?authSource=${MONGO_AUTHENTICATION_DATABASE}"
+    mongosh "$uri" --quiet --eval "db.runCommand({ ping: 1 })" >/dev/null 2>&1
+}
+
+port_in_use() {
+    local port="$1"
+    if command -v ss >/dev/null 2>&1; then
+        ss -ltn 2>/dev/null | awk '{print $4}' | grep -q ":${port}$"
+    elif command -v lsof >/dev/null 2>&1; then
+        lsof -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1
+    else
+        return 1
+    fi
+}
+
+start_mongo() {
+    log_info "Checking MongoDB..."
+    
+    if ping_mongo; then
+        log_success "MongoDB is already running and accessible"
+        return 0
+    fi
+    
+    if port_in_use "$MONGO_PORT"; then
+        log_error "Port $MONGO_PORT is in use, but MongoDB credentials don't work"
+        log_error "You may need to:"
+        log_error "  1. Check your MongoDB credentials, or"
+        log_error "  2. Stop the existing MongoDB instance, or"
+        log_error "  3. Adjust MONGO_* environment variables"
+        exit 1
+    fi
+    
+    log_info "Starting local MongoDB..."
+    
+    MONGO_DATA_DIR="${BACKEND_DIR}/.local-mongo"
+    
+    if [[ "$RESET_DB" == "1" && -d "$MONGO_DATA_DIR" ]]; then
+        log_warn "Removing existing MongoDB data directory..."
+        rm -rf "$MONGO_DATA_DIR"
+    fi
+    
+    mkdir -p "$MONGO_DATA_DIR"
+    
+    # If fresh data dir, create admin user first
+    if [[ ! -f "${MONGO_DATA_DIR}/WiredTiger" ]]; then
+        log_info "Initializing MongoDB data directory..."
+        
+        mongod \
+            --dbpath "$MONGO_DATA_DIR" \
+            --bind_ip "$MONGO_HOST" \
+            --port "$MONGO_PORT" \
+            --fork \
+            --logpath "${LOG_DIR}/mongo.log" \
+            --pidfilepath "${LOG_DIR}/mongo.pid"
+        
+        # Wait for MongoDB to be ready
+        sleep 2
+        
+        log_info "Creating initial admin user..."
+        mongosh "mongodb://${MONGO_HOST}:${MONGO_PORT}/admin" --quiet <<EOF
+const adminDb = db.getSiblingDB('admin');
+try {
+    adminDb.createUser({
+        user: '${MONGO_USERNAME}',
+        pwd: '${MONGO_PASSWORD}',
+        roles: [{ role: 'readWrite', db: '${MONGO_DATABASE}' }]
+    });
+    print('User created successfully');
+} catch (e) {
+    if (e.codeName === "UserAlreadyExists" || e.code === 51003) {
+        print('User already exists');
+    } else {
+        throw e;
+    }
+}
+EOF
+        
+        log_info "Restarting MongoDB with authentication..."
+        mongod --dbpath "$MONGO_DATA_DIR" --shutdown 2>/dev/null || true
+        sleep 1
+    fi
+    
+    # Start MongoDB with auth
+    mongod \
+        --dbpath "$MONGO_DATA_DIR" \
+        --bind_ip "$MONGO_HOST" \
+        --port "$MONGO_PORT" \
+        --auth \
+        --fork \
+        --logpath "${LOG_DIR}/mongo.log" \
+        --pidfilepath "$MONGO_PID_FILE"
+    
+    # Wait and verify
+    local attempts=0
+    while ! ping_mongo && [[ $attempts -lt 10 ]]; do
+        sleep 1
+        ((attempts++))
+    done
+    
+    if ping_mongo; then
+        log_success "MongoDB started successfully"
+    else
+        log_error "MongoDB failed to start"
+        exit 1
+    fi
+}
+
+# Backend functions
+setup_wechat_keys() {
+    log_info "Setting up WeChat dummy keys..."
+    
+    WECHAT_KEY_DIR="${BACKEND_DIR}/.local-wechat-keys"
+    WECHAT_PRIVATE_CANDIDATE="${SCRIPT_DIR}/wechat-mch-private.pem"
+    WECHAT_PUBLIC_CANDIDATE="${SCRIPT_DIR}/wechatpay-pub.pem"
+    
+    if [[ -f "$WECHAT_PRIVATE_CANDIDATE" && -f "$WECHAT_PUBLIC_CANDIDATE" ]]; then
+        export WECHAT_PRIVATE_KEY_PATH="$WECHAT_PRIVATE_CANDIDATE"
+        export WECHATPAY_PUBLIC_KEY_PATH="$WECHAT_PUBLIC_CANDIDATE"
+        log_success "Using existing WeChat keys from test/"
+    else
+        mkdir -p "$WECHAT_KEY_DIR"
+        if [[ ! -f "${WECHAT_KEY_DIR}/merchant-private.pem" ]]; then
+            if ! command -v openssl >/dev/null 2>&1; then
+                log_error "openssl not found; cannot generate dummy WeChat keys"
+                exit 1
+            fi
+            openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 \
+                -out "${WECHAT_KEY_DIR}/merchant-private.pem" >/dev/null 2>&1
+            openssl rsa -in "${WECHAT_KEY_DIR}/merchant-private.pem" -pubout \
+                -out "${WECHAT_KEY_DIR}/wechatpay-public.pem" >/dev/null 2>&1
+        fi
+        export WECHAT_PRIVATE_KEY_PATH="${WECHAT_KEY_DIR}/merchant-private.pem"
+        export WECHATPAY_PUBLIC_KEY_PATH="${WECHAT_KEY_DIR}/wechatpay-public.pem"
+        log_success "Generated new dummy WeChat keys"
+    fi
+}
+
+build_backend() {
+    if [[ "$SKIP_BUILD" == "1" ]]; then
+        log_info "Skipping backend build (--skip-build)"
+        return 0
+    fi
+    
+    log_info "Building backend with Maven..."
+    
+    # Use local Maven repo
+    export MAVEN_USER_HOME="${BACKEND_DIR}/.m2"
+    export MAVEN_LOCAL_REPO="${MAVEN_USER_HOME}/repository"
+    mkdir -p "$MAVEN_USER_HOME"
+    
+    (cd "$BACKEND_DIR" && mvn -Dmaven.repo.local="$MAVEN_LOCAL_REPO" -DskipTests clean package)
+    
+    log_success "Backend build completed"
+}
+
+init_database() {
+    if [[ "$SKIP_DB_INIT" == "1" ]]; then
+        log_info "Skipping database initialization (--skip-db-init)"
+        return 0
+    fi
+    
+    log_info "Initializing database..."
+    
+    # Export all needed env vars for the init script
+    export MONGO_HOST MONGO_PORT MONGO_DATABASE MONGO_USERNAME MONGO_PASSWORD MONGO_AUTHENTICATION_DATABASE
+    export ADMIN_USERNAME ADMIN_PASSWORD
+    export MAVEN_USER_HOME="${BACKEND_DIR}/.m2"
+    export MAVEN_LOCAL_REPO="${MAVEN_USER_HOME}/repository"
+    
+    # Source and run the init script
+    # shellcheck source=./dev-init-db.sh
+    source "${SCRIPT_DIR}/dev-init-db.sh"
+}
+
+start_backend() {
+    log_info "Starting backend..."
+    
+    local jar_path
+    jar_path=$(ls -1 "${BACKEND_DIR}/target/"*.jar 2>/dev/null | grep -v '\.original$' | head -n 1 || true)
+    
+    if [[ -z "$jar_path" ]]; then
+        log_error "Backend JAR not found. Build may have failed."
+        exit 1
+    fi
+    
+    # Set up environment
+    export SERVER_PORT
+    export MONGO_HOST MONGO_PORT MONGO_DATABASE MONGO_USERNAME MONGO_PASSWORD MONGO_AUTHENTICATION_DATABASE
+    
+    LOCAL_STATIC_DIR="${BACKEND_DIR}/.local-static"
+    mkdir -p "$LOCAL_STATIC_DIR"
+    export FILE_UPLOAD_DIR="$LOCAL_STATIC_DIR"
+    export SPRING_WEB_RESOURCES_STATIC_LOCATIONS="file:${LOCAL_STATIC_DIR}/"
+    export APP_URL="http://localhost:${SERVER_PORT}"
+    
+    # WeChat config
+    setup_wechat_keys
+    export WECHAT_APPID="${WECHAT_APPID:-wx_local}"
+    export WECHAT_SECRET="${WECHAT_SECRET:-local_secret}"
+    export WECHAT_MCHID="${WECHAT_MCHID:-1900000109}"
+    export WECHAT_MERCHANT_SERIAL_NUMBER="${WECHAT_MERCHANT_SERIAL_NUMBER:-local_serial}"
+    export WECHAT_API_V3_KEY="${WECHAT_API_V3_KEY:-0123456789ABCDEF0123456789ABCDEF}"
+    export WECHATPAY_PUBLIC_KEY_ID="${WECHATPAY_PUBLIC_KEY_ID:-local_wechatpay_key}"
+    export WECHATPAY_NOTIFICATION_USE_COMBINED="${WECHATPAY_NOTIFICATION_USE_COMBINED:-false}"
+    export WECHAT_PREPAY_NOTIFY_URL="http://localhost:${SERVER_PORT}/wechat/prepay_notify"
+    export WECHAT_REFUND_NOTIFY_URL="http://localhost:${SERVER_PORT}/wechat/refund_notify"
+    export WECHAT_STATE="${WECHAT_STATE:-local}"
+    
+    # Start backend
+    local backend_log
+    backend_log="${LOG_DIR}/backend_$(date +%Y%m%d_%H%M%S).log"
+    
+    java -Dfile.encoding=utf-8 -jar "$jar_path" >"$backend_log" 2>&1 &
+    local backend_pid=$!
+    echo "$backend_pid" > "$BACKEND_PID_FILE"
+    
+    # Wait for backend to be ready
+    log_info "Waiting for backend to start..."
+    local attempts=0
+    while [[ $attempts -lt 30 ]]; do
+        if curl -s "http://localhost:${SERVER_PORT}/actuator/health" >/dev/null 2>&1 || \
+           curl -s "http://localhost:${SERVER_PORT}" >/dev/null 2>&1; then
+            break
+        fi
+        if ! kill -0 "$backend_pid" 2>/dev/null; then
+            log_error "Backend process died. Check log: $backend_log"
+            exit 1
+        fi
+        sleep 1
+        ((attempts++))
+        echo -n "."
+    done
+    echo ""
+    
+    if kill -0 "$backend_pid" 2>/dev/null; then
+        log_success "Backend started (PID: $backend_pid)"
+        log_info "Backend log: $backend_log"
+    else
+        log_error "Backend failed to start. Check log: $backend_log"
+        exit 1
+    fi
+}
+
+# Frontend functions
+setup_frontend_env() {
+    log_info "Configuring frontend environment..."
+    
+    # Create .env.local for development (gitignored, takes precedence)
+    local env_file="${FRONTEND_DIR}/.env.local"
+    
+    cat > "$env_file" << EOF
+# Auto-generated by dev-start.sh
+# This file is gitignored and overrides .env.development
+VITE_API_BASE_URL=http://localhost:${SERVER_PORT}
+VITE_HIPRINT_HOST=http://localhost:17521
+EOF
+    
+    log_success "Frontend environment configured (.env.local)"
+    log_info "API URL: http://localhost:${SERVER_PORT}"
+}
+
+start_frontend() {
+    log_info "Setting up frontend..."
+    
+    if [[ ! -d "${FRONTEND_DIR}/node_modules" ]]; then
+        log_info "Installing frontend dependencies (this may take a while)..."
+        (cd "$FRONTEND_DIR" && npm install)
+    fi
+    
+    setup_frontend_env
+    
+    log_info "Starting frontend dev server..."
+    log_info "Once started, access the frontend at: http://localhost:${FRONTEND_PORT}"
+    echo ""
+    log_info "Press Ctrl+C to stop"
+    echo ""
+    
+    cd "$FRONTEND_DIR"
+    npm run dev -- --host --port "$FRONTEND_PORT"
+}
+
+# Cleanup
+cleanup_on_exit() {
+    if [[ -f "$BACKEND_PID_FILE" ]]; then
+        local pid
+        pid=$(cat "$BACKEND_PID_FILE" 2>/dev/null || true)
+        if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+            log_info "Stopping backend (PID: $pid)..."
+            kill "$pid" 2>/dev/null || true
+        fi
+        rm -f "$BACKEND_PID_FILE"
+    fi
+    
+    # Clean up frontend .env.local
+    local env_file="${FRONTEND_DIR}/.env.local"
+    if [[ -f "$env_file" ]]; then
+        rm -f "$env_file"
+        log_info "Cleaned up frontend environment"
+    fi
+    
+    echo ""
+    log_info "Development environment stopped"
+}
+
+# Main
+main() {
+    parse_args "$@"
+    
+    # Check for conflicting flags
+    if [[ "$BACKEND_ONLY" == "1" && "$FRONTEND_ONLY" == "1" ]]; then
+        log_error "Cannot use both --backend-only and --frontend-only"
+        exit 1
+    fi
+    
+    print_banner
+    
+    # Check prerequisites
+    need_cmd git
+    need_cmd java
+    need_cmd mongosh
+    need_cmd mongod
+    
+    if [[ "$FRONTEND_ONLY" != "1" ]]; then
+        need_cmd mvn
+    fi
+    
+    if [[ "$BACKEND_ONLY" != "1" ]]; then
+        need_cmd node
+        need_cmd npm
+    fi
+    
+    # Setup Java version
+    setup_java
+    
+    show_repo_info
+    
+    if [[ "$FRONTEND_ONLY" != "1" ]]; then
+        start_mongo
+        build_backend
+        init_database
+        start_backend
+    fi
+    
+    if [[ "$BACKEND_ONLY" != "1" ]]; then
+        if [[ "$FRONTEND_ONLY" == "1" ]]; then
+            # Check if backend is running
+            if ! curl -s "http://localhost:${SERVER_PORT}" >/dev/null 2>&1; then
+                log_warn "Backend doesn't seem to be running on port ${SERVER_PORT}"
+                log_warn "Make sure to start it first with: $0 --backend-only"
+                echo ""
+                # Auto-continue if not running interactively (tty)
+                if [[ -t 0 ]]; then
+                    read -p "Continue anyway? [y/N] " -n 1 -r
+                    echo ""
+                    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+                        exit 1
+                    fi
+                else
+                    log_info "Non-interactive mode, continuing anyway..."
+                fi
+            fi
+        fi
+        
+        # Set up trap to clean up backend when frontend exits (if we started it)
+        if [[ "$FRONTEND_ONLY" != "1" ]]; then
+            trap cleanup_on_exit EXIT INT TERM
+        fi
+        
+        start_frontend
+    else
+        # Backend only mode - keep running
+        echo ""
+        log_success "Backend is running on http://localhost:${SERVER_PORT}"
+        log_info "API Documentation: http://localhost:${SERVER_PORT}/swagger-ui.html"
+        log_info "Admin login: ${ADMIN_USERNAME} / ${ADMIN_PASSWORD}"
+        echo ""
+        log_info "Press Ctrl+C to stop"
+        
+        # Wait for interrupt
+        trap 'echo ""; log_info "Stopping..."; cleanup_on_exit; exit 0' INT TERM
+        while true; do
+            sleep 1
+        done
+    fi
+}
+
+main "$@"

--- a/dev-scripts/dev-stop.sh
+++ b/dev-scripts/dev-stop.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# dev-stop.sh - Stop the Chimera Coffee development environment
+#
+# This script stops:
+#   - Backend Java process (via PID file)
+#   - Local MongoDB instance (via PID file)
+#
+# Usage:
+#   ./dev-stop.sh           # Stop backend and MongoDB
+#   ./dev-stop.sh --soft    # Stop only backend, keep MongoDB running
+#   ./dev-stop.sh --clean   # Stop everything and remove MongoDB data
+
+# Auto-detect directory structure
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)"
+
+if [[ -f "${SCRIPT_DIR}/../pom.xml" ]]; then
+    # We're in ChimeraCoffee/dev-scripts/ (new structure)
+    BACKEND_DIR="${SCRIPT_DIR}/.."
+else
+    # We're in project_root/test/ (legacy structure)
+    BACKEND_DIR="${SCRIPT_DIR}/../ChimeraCoffee"
+fi
+
+LOG_DIR="${BACKEND_DIR}/log"
+MONGO_DATA_DIR="${BACKEND_DIR}/.local-mongo"
+
+BACKEND_PID_FILE="${LOG_DIR}/backend.pid"
+MONGO_PID_FILE="${LOG_DIR}/mongo.pid"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info() { echo -e "${BLUE}[STOP]${NC} $*"; }
+log_warn() { echo -e "${YELLOW}[STOP]${NC} $*"; }
+log_error() { echo -e "${RED}[STOP]${NC} $*"; }
+log_success() { echo -e "${GREEN}[STOP]${NC} $*"; }
+
+SOFT_MODE=0
+CLEAN_MODE=0
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --soft)
+                SOFT_MODE=1
+                shift
+                ;;
+            --clean)
+                CLEAN_MODE=1
+                shift
+                ;;
+            --help|-h)
+                echo "Usage: $0 [options]"
+                echo ""
+                echo "Options:"
+                echo "  --soft     Stop only backend, keep MongoDB running"
+                echo "  --clean    Stop everything and remove MongoDB data directory"
+                echo "  --help, -h Show this help"
+                echo ""
+                exit 0
+                ;;
+            *)
+                log_error "Unknown option: $1"
+                exit 1
+                ;;
+        esac
+    done
+}
+
+stop_by_pid_file() {
+    local label="$1"
+    local pid_file="$2"
+    local signal="${3:-TERM}"
+    
+    if [[ ! -f "$pid_file" ]]; then
+        log_warn "$label: no PID file found ($pid_file)"
+        return 1
+    fi
+    
+    local pid
+    pid=$(cat "$pid_file" 2>/dev/null || true)
+    
+    if [[ -z "$pid" ]]; then
+        log_warn "$label: PID file is empty"
+        rm -f "$pid_file"
+        return 1
+    fi
+    
+    if ! kill -0 "$pid" 2>/dev/null; then
+        log_warn "$label: process not running (PID: $pid)"
+        rm -f "$pid_file"
+        return 1
+    fi
+    
+    log_info "$label: stopping (PID: $pid)..."
+    
+    if kill -"$signal" "$pid" 2>/dev/null; then
+        # Wait for process to actually stop
+        local attempts=0
+        while kill -0 "$pid" 2>/dev/null && [[ $attempts -lt 10 ]]; do
+            sleep 0.5
+            ((attempts++))
+        done
+        
+        if kill -0 "$pid" 2>/dev/null; then
+            log_warn "$label: still running, forcing kill..."
+            kill -9 "$pid" 2>/dev/null || true
+        fi
+        
+        log_success "$label: stopped"
+    else
+        log_error "$label: failed to stop"
+    fi
+    
+    rm -f "$pid_file"
+}
+
+stop_backend() {
+    stop_by_pid_file "Backend" "$BACKEND_PID_FILE" "TERM"
+}
+
+stop_mongo() {
+    if [[ "$SOFT_MODE" == "1" ]]; then
+        log_info "Soft mode: keeping MongoDB running"
+        return 0
+    fi
+    
+    stop_by_pid_file "MongoDB" "$MONGO_PID_FILE" "TERM"
+    
+    if [[ "$CLEAN_MODE" == "1" ]]; then
+        if [[ -d "$MONGO_DATA_DIR" ]]; then
+            log_info "Removing MongoDB data directory..."
+            rm -rf "$MONGO_DATA_DIR"
+            log_success "MongoDB data removed"
+        fi
+    fi
+}
+
+cleanup_frontend_env() {
+    # Auto-detect frontend location
+    if [[ -f "${SCRIPT_DIR}/../pom.xml" ]]; then
+        # We're in ChimeraCoffee/dev-scripts/
+        local env_file="${SCRIPT_DIR}/../../chimera-management/.env.local"
+    else
+        # We're in project_root/test/
+        local env_file="${SCRIPT_DIR}/../chimera-management/.env.local"
+    fi
+    
+    if [[ -f "$env_file" ]]; then
+        log_info "Cleaning up frontend environment..."
+        rm -f "$env_file"
+        log_success "Frontend environment cleaned"
+    fi
+    
+    # Also clean up legacy backup file if it exists
+    local customize_file
+    if [[ -f "${SCRIPT_DIR}/../pom.xml" ]]; then
+        customize_file="${SCRIPT_DIR}/../../chimera-management/src/client/customize.ts"
+    else
+        customize_file="${SCRIPT_DIR}/../chimera-management/src/client/customize.ts"
+    fi
+    local backup_file="${customize_file}.dev.bak"
+    if [[ -f "$backup_file" ]]; then
+        rm -f "$backup_file"
+    fi
+}
+
+print_summary() {
+    echo ""
+    log_success "Cleanup complete"
+    echo ""
+    
+    if [[ "$CLEAN_MODE" == "1" ]]; then
+        log_info "MongoDB data directory has been removed"
+        log_info "Next start will create fresh data"
+    elif [[ "$SOFT_MODE" != "1" ]]; then
+        log_info "MongoDB data is preserved at: $MONGO_DATA_DIR"
+        log_info "To also remove data, use: $0 --clean"
+    fi
+    
+    echo ""
+    log_info "To restart: ./dev-start.sh"
+}
+
+main() {
+    parse_args "$@"
+    
+    echo ""
+    echo "╔══════════════════════════════════════════════════╗"
+    echo "║    Chimera Coffee - Dev Environment Stop         ║"
+    echo "╚══════════════════════════════════════════════════╝"
+    echo ""
+    
+    stop_backend
+    stop_mongo
+    cleanup_frontend_env
+    print_summary
+}
+
+main "$@"

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.chimera</groupId>
 	<artifactId>yuanqi</artifactId>
-	<version>recv3u1wizB7aZ</version>
+	<version>recv3A5DbVtBAl</version>
 	<name>weapp</name>
 	<description>Demo project for Chimera</description>
 	<url/>

--- a/src/main/java/com/chimera/weapp/config/SwaggerConfig.java
+++ b/src/main/java/com/chimera/weapp/config/SwaggerConfig.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.models.info.License;
 import io.swagger.v3.oas.models.servers.Server;
 import io.swagger.v3.oas.models.media.StringSchema;
 import org.bson.types.ObjectId;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -16,24 +17,27 @@ import java.util.Collections;
 @Configuration
 public class SwaggerConfig {
 
+    @Value("${app.url:https://www.chimeracoffee.top}")
+    private String appUrl;
+
     @Bean
     @Primary
     public OpenAPI customOpenAPI() {
-        // 定义服务器信息
+        // 定义服务器信息 - 使用环境变量配置的URL
         Server server = new Server();
-        server.setUrl("https://www.chimeracoffee.top");
-        server.setDescription("Production server");
+        server.setUrl(appUrl);
+        server.setDescription("API Server");
 
         return new OpenAPI()
                 .info(new Info()
-                        .title("SpringShop API")
-                        .description("Spring shop sample application")
+                        .title("Chimera Coffee API")
+                        .description("Chimera Coffee Shop Management API")
                         .version("v0.0.1")
                         .license(new License().name("Apache 2.0").url("http://springdoc.org")))
                 .servers(Collections.singletonList(server))
                 .externalDocs(new ExternalDocumentation()
-                        .description("SpringShop Wiki Documentation")
-                        .url("https://springshop.wiki.github.org/docs"))
+                        .description("Documentation")
+                        .url("https://github.com/your-org/chimera-coffee"))
                 .components(new io.swagger.v3.oas.models.Components()
                         .addSchemas(ObjectId.class.getSimpleName(), new StringSchema()));
     }

--- a/src/main/java/com/chimera/weapp/entity/Product.java
+++ b/src/main/java/com/chimera/weapp/entity/Product.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import com.chimera.weapp.vo.OptionValue;
+import com.chimera.weapp.vo.InventoryUsage;
 import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
@@ -48,6 +49,8 @@ public class Product {
     private Boolean needStockWithRestrictBuy;
     @Schema(description = "库存数量，为0时前端提示已售罄并不可下单")
     private int stock;
+    @Schema(description = "原料信息和用量列表")
+    private List<InventoryUsage> inventoryList;
     @Schema(description = "预售买数量，补货后清零")
     private int presaleNum;
     @Schema(description = "当天是否已补货，0点设为False")

--- a/src/main/java/com/chimera/weapp/vo/InventoryUsage.java
+++ b/src/main/java/com/chimera/weapp/vo/InventoryUsage.java
@@ -1,0 +1,19 @@
+package com.chimera.weapp.vo;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InventoryUsage {
+    @NotNull
+    private String uuid;
+    @Schema(description = "用量")
+    private double amount;
+}

--- a/src/main/java/com/chimera/weapp/vo/OptionValue.java
+++ b/src/main/java/com/chimera/weapp/vo/OptionValue.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -18,4 +20,6 @@ public class OptionValue {
     private String value;
     @Schema(description = "该可选项的价格调整，>=0。单位也为分。")
     private int priceAdjustment;
+    @Schema(description = "额外原料信息和用量列表")
+    private List<InventoryUsage> inventoryList;
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,17 +5,17 @@ spring.mvc.pathmatch.matching-strategy=ant-path-matcher
 spring.data.mongodb.uri=mongodb://${MONGO_USERNAME}:${MONGO_PASSWORD}@${MONGO_HOST}:${MONGO_PORT}/${MONGO_DATABASE}?authSource=${MONGO_AUTHENTICATION_DATABASE}
 spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration,org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
 
-file.upload-dir=/home/chimera/static/
-app.url=https://chimeracoffee.top/
-spring.web.resources.static-locations=file:/home/chimera/static/
+file.upload-dir=${FILE_UPLOAD_DIR:/home/chimera/static/}
+app.url=${APP_URL:https://chimeracoffee.top/}
+spring.web.resources.static-locations=${SPRING_WEB_RESOURCES_STATIC_LOCATIONS:file:/home/chimera/static/}
 spring.servlet.multipart.enabled=true
 spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=10MB
-spring.jackson.time-zone=Asia/Shanghai
+spring.jackson.time-zone=${TIMEZONE:Asia/Shanghai}
 
-
-spring.jpa.hibernate.ddl-auto=update
-spring.jpa.show-sql=true
+# JPA (mostly unused with MongoDB, but kept for compatibility)
+spring.jpa.hibernate.ddl-auto=${JPA_DDL_AUTO:update}
+spring.jpa.show-sql=${JPA_SHOW_SQL:true}
 
 wx-mini-program.appid=${WECHAT_APPID}
 wx-mini-program.secret=${WECHAT_SECRET}


### PR DESCRIPTION
# PR: feat: 商品原料消耗配置与订单原料批量统计 (recv3A5DbVtBAl)

## 需求

**需求ID**: recv3A5DbVtBAl

**目标**: 支持为商品和商品选项配置原料消耗量，并在订单管理中批量计算选中订单的原料总用量，便于库存管理和备料准备。

---

## 方案

### 后端 (ChimeraCoffee)

1. **新增 InventoryUsage VO** (`src/main/java/com/chimera/weapp/vo/InventoryUsage.java`)
   - 包含 `uuid` (原料ID) 和 `amount` (用量) 字段
   - 用于记录单个原料的消耗配置

2. **扩展 Product 实体**
   - 新增 `inventoryList: List<InventoryUsage>` 字段
   - 支持为商品配置基础原料消耗

3. **扩展 OptionValue VO**
   - 新增 `inventoryList: List<InventoryUsage>` 字段
   - 支持为商品选项值配置额外原料消耗（如加料、规格升级等）

4. **开发环境脚本** (`dev-scripts/`)
   - `dev-start.sh`: 一键启动开发环境（MongoDB + 后端 + 前端）
   - `dev-stop.sh`: 停止所有开发服务
   - `dev-init-db.sh`: 初始化开发数据库
   - `dev-info.sh`: 检查开发环境状态
   - 支持环境变量配置，提供本地开发便利

5. **配置化改造**
   - `application.properties`: 硬编码值改为环境变量（`APP_URL`, `FILE_UPLOAD_DIR` 等）
   - `SwaggerConfig`: 支持从环境变量读取 API URL

### 前端 (chimera-management)

1. **商品原料配置** (`Product.vue`)
   - 编辑商品时可为商品添加原料消耗列表
   - 选择原料 + 输入用量，实时显示单位
   - 支持删除已配置原料

2. **商品选项原料配置** (`ProductOpt.vue`)
   - 为选项值（如大杯、加珍珠等）配置额外原料消耗
   - 每个选项值独立配置原料列表
   - 在选项列表中展示原料消耗预览

3. **订单原料批量计算** (`Order.vue`)
   - 新增 "批量计算原料使用" 按钮
   - 选中订单后点击，自动计算所有原料总消耗量
   - 计算逻辑：遍历选中订单 → 累加商品基础原料 + 选项额外原料
   - 结果在页面顶部统计区域展示（复用 inventories 列表，用 remain 字段表示消耗量）

4. **分页配置化** (`Order.vue`)
   - 默认每页显示 30 条订单（原为 15）
   - 支持从 AppConfiguration 读取 `order.list.pageSize` 配置
   - 分页组件增加 page-size 选择器（可选 10/20/30/50/100）

5. **开发环境配置** (`.env` 系列文件)
   - `.env`: 默认环境变量
   - `.env.development`: 开发环境配置（localhost）
   - `.env.production`: 生产环境配置
   - 支持 `VITE_API_BASE_URL` 和 `VITE_HIPRINT_HOST` 配置

6. **WebSocket 心跳修复**
   - 忽略服务器返回的 `"pong"` 心跳消息，避免 JSON 解析错误

---

## 验证

### 后端验证

```bash
# 1. 启动开发环境
./dev-scripts/dev-start.sh

# 2. 检查服务状态
./dev-scripts/dev-info.sh
# 输出：
# [OK] Java version: 17
# [OK] MongoDB is running on port 27017
# [OK] Backend built successfully
# [OK] Frontend dependencies installed

# 3. 检查 API 文档
open http://localhost:8088/swagger-ui.html
# 确认 InventoryUsage 字段已包含在 Product 和 OptionValue 模型中
```

### 前端验证

```bash
# 1. 本地启动
npm run dev

# 2. 商品原料配置验证
# - 进入商品管理 → 编辑商品
# - 添加原料（如：咖啡豆 10g、牛奶 100ml）
# - 保存后重新编辑，确认原料列表正确保存

# 3. 商品选项原料配置验证  
# - 进入商品选项管理 → 编辑选项
# - 为选项值添加额外原料（如：大杯 +50ml 牛奶）
# - 保存后在列表中查看原料预览

# 4. 订单原料批量计算验证
# - 进入订单列表，勾选多个订单
# - 点击 "批量计算原料使用"
# - 验证顶部统计区域显示各原料总消耗量

# 5. 分页配置验证
# - 在配置表添加 order.list.pageSize = 50
# - 刷新订单列表，确认每页显示 50 条
```

### 生产部署验证

```bash
# 后端
./new_mer_start.sh --skip-build

# 前端
npm run build
# 部署后验证：
# - 确认分页默认为 30 条
# - 确认 API 请求指向正确地址
```

---

## 风险与回滚

### 风险分析

| 风险项 | 影响 | 缓解措施 |
|--------|------|----------|
| 新增 inventoryList 字段 | 旧数据无该字段，可能为 null | 代码中做空值检查（`product.inventoryList?`） |
| 环境变量配置变更 | 生产环境未设置新变量时使用默认值 | 所有环境变量均有合理的默认值 |
| 分页数量变更 | 用户习惯每页 15 条，现为 30 条 | 可通过配置表随时调整 |
| 开发脚本安全性 | 脚本包含默认密码（admin/admin123） | 脚本目录添加 README 安全警告，仅用于本地开发 |

### 兼容性

- **接口兼容**: 新增字段为可选，不影响旧接口调用
- **数据兼容**: 旧数据无 inventoryList 时，前端按空数组处理
- **配置兼容**: 未配置 order.list.pageSize 时使用默认值 30

### 回滚方式

1. **前端回滚**: 
   ```bash
   git revert <PR_COMMIT>
   npm run build && deploy
   ```

2. **后端回滚**:
   ```bash
   git revert <PR_COMMIT>
   ./new_mer_start.sh --skip-build
   ```

3. **数据库变更回滚**:
   - 本 PR 无数据库 schema 变更（MongoDB 无固定 schema）
   - 如需清除测试数据，运行 `dev-scripts/dev-stop.sh --reset-db`

---

## 相关 Commit

### Backend (ChimeraCoffee)
- `9d282ca` feat: 增加 InventoryUsage 相关后端接口 (recv3A5DbVtBAl) (#7)
- `84fa8d7` feat: 开发环境一键启动脚本与数据库初始化 (recv3A5DbVtBAl)

### Frontend (chimera-management)
- `72961bd` feat: 支持配置商品(选项)的原料消耗量，和批量计算订单原料总量 (recv3A5DbVtBAl) (#9)
- `fca6dd7` feat: 前端开发环境配置与WebSocket心跳修复 (recv3A5DbVtBAl)
- `b3690dd` fix: type error during npm build (recv3A5DbVtBAl)
- `3e90d55` feat: load page size configuration from app settings
